### PR TITLE
Support typed and untyped mutagen File

### DIFF
--- a/src/overcast_data/overcast.py
+++ b/src/overcast_data/overcast.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import Literal, NewType, cast
+from typing import Any, Literal, NewType, cast
 from urllib.parse import urlparse
 
 import dateutil.parser
@@ -635,7 +635,7 @@ def _fetch_audio_duration(url: HTTPURL) -> timedelta | None:
         return None
     io = BytesIO(response.content)
     try:
-        f = mutagen.File(io)  # type: ignore
+        f = cast(Any, getattr(mutagen, "File"))(io)
     except Exception:
         logger.error("Failed to parse audio: %s", url)
         return None


### PR DESCRIPTION
### Motivation
- Fix a mypy error caused by version differences in `mutagen.File` so the code type-checks against both older untyped and newer typed `mutagen` releases while keeping the existing dependency range.

### Description
- Replace the version-sensitive `mutagen.File(io)  # type: ignore` with `f = cast(Any, getattr(mutagen, "File"))(io)` and import `Any` so mypy accepts both untyped and typed `mutagen` implementations.

### Testing
- Ran `.venv/bin/mypy src/overcast_data/overcast.py` and `.venv/bin/mypy .` which succeeded.
- Ran `.venv/bin/ruff check .` which succeeded.
- Ran `.venv/bin/pytest` which reported 4 failing tests, but the failures are due to outbound HTTPS requests being blocked by the environment proxy (403) and are unrelated to the typing change; installing `mutagen==1.48.1` could not be completed in this environment due to the same network/proxy errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53d2f2ddcc8326891b303108c18843)